### PR TITLE
docs: add documentation of 5.4 features

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -8,8 +8,8 @@ nav:
 asciidoc:
   attributes:
     theme: docs
-    connector-version: '5.3'
-    exact-connector-version: '5.3.10'
+    connector-version: '5.4'
+    exact-connector-version: '5.4.0'
     scala-version: '2.12'
     exact-scala-version: '2.12.20'
     spark-version: '3.5.6'

--- a/modules/ROOT/pages/read/options.adoc
+++ b/modules/ROOT/pages/read/options.adoc
@@ -66,6 +66,11 @@ your Neo4j installation.
 |`1`
 |No
 
+|`type.conversion` label:new[v5.4]
+|Data conversion logic. When set to `legacy`, timestamps, intervals and byte arrays are processed the same way as they were before 5.4.0. See xref:../types.adoc[] for more information.
+|`default`
+|No
+
 4+|*Query specific options*
 
 |`query.count`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -32,7 +32,7 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 |v5.4.0
 |Example: `"16725.77423461"`
 This mapping only applies when _writing_ to Neo4j.
-If you need to read a spark `decimal`, please parse the string representation in an appropriate way for your use case.
+If you need to read a spark `decimal`, parse the string representation in an appropriate way for your use case.
 
 |`Boolean`
 |`boolean`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -10,115 +10,104 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 
 .Spark to Neo4j type mapping reference
 |===
-|Neo4j type |Spark type |Since | Notes
+|Neo4j type |Spark type | Notes
 
 |`String`
 |`string`
-|
 |Example: `"Hello"`
 
 |`Integer`
 |`long`, `short`, `byte`
-|
 |Example:  `12345`
 
 |`Float`
 |`double`
-|
 |Example: `3.141592`
 
 |`String`
 |`decimal` label:new[New in 5.4.0]
-|v5.4.0
 |Example: `"16725.77423461"`
 This mapping only applies when _writing_ to Neo4j.
 If you need to read a spark `decimal`, parse the string representation in an appropriate way for your use case.
 
 |`Boolean`
 |`boolean`
-|
 |Example:  `true`
 
 |`Point`
 |`struct { type: string, srid: integer, x: double, y: double, z: double }`
-|
 |For more information on spatial types in Neo4j, see link:https://neo4j.com/docs/cypher-manual/current/values-and-types/spatial/[Spatial values]
 
 |`Date`
 |`date`
-|
 |Example: `2020-09-11`
 
 |`Time`
 |`struct { type: string, value: string }`
-|
 |Example: `[offset-time, 12:14:08.209Z]`
 
 |`LocalTime`
 |`struct { type: string, value: string }`
-|
 |Example: `[local-time, 12:18:11.628]`
 
 |`ZonedDateTime`
-|`timestamp`
-|v5.4.0*
+|`timestamp` label:new[New in 5.4.0]
 |Example: `2020-09-11 12:17:39.192+02:00`
-Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC. 
-Prior to 5.4.0. these timestamps are written as `LocalDateTime`.
-This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
+Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC.
 
 |`LocalDateTime`
-|`timestamp_ntz`
-|v5.4.0*
+|`timestamp`
+|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
+
+|`LocalDateTime`
+|`timestamp_ntz` label:new[New in 5.4.0]
 |Example: `2020-09-11 12:14:49.081`
 Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. 
-Prior to 5.4.0. these timestamps are written as a numerical value.
-This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
+
+|`Integer`
+|`timestamp_ntz`
+|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
 
 |`Duration`
 |`struct { type: string, months: long, days: long, seconds: long, nanonseconds: integer, value: string }`
-|
 |See link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Temporal functions: duration].
 
 |`Duration`
+|`duration` or `period` objects label:new[New in 5.4.0]
+|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`.
+
+|`Long`
 |`duration` or `period` objects
-|v5.4.0*
-|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`. 
-Prior to 5.4.0, Spark durations and intervals are stored as `long`.
-This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
+|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
 
 |`Duration`
-|Spark SQL `INTERVAL` types
-|v5.4.0*
+|Spark SQL `INTERVAL` types label:new[New in 5.4.0]
 |Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`.
-Prior to 5.4.0, Spark durations and intervals are stored as `long`.
-This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
+
+|`Long`
+|Spark SQL `INTERVAL` types
+|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
 
 |`Node`
 |`struct { <id>: long, <labels>: array[string], (PROPERTIES) }`
-|
 |Nodes in Neo4j are represented as property containers; that is they appear as structs with properties corresponding to whatever properties were in the node.  _For ease of use it is usually better to return individual properties than a node from a query._
 
 |`Relationship`
 |`struct { <rel.id>: long, <rel.type>: string, <source.id>: long, <target.id>: long, (PROPERTIES) }`
-|
 |Relationships are returned as maps, identifying the source and target of the relationship, its type, along with properties (if any) of the relationship.  _For ease of use it is usually better to return individual properties than a relationship from a query._
 
 |`Path`
 |`string`
-|
 |Example: `path[(322)<-[20280:AIRLINE]-(33510)]`.  _For ease of use it is recommended to use link:https://neo4j.com/docs/cypher-manual/current/values-and-types/lists/[path functions] to return individual properties/aspects of a path from a query._
 
 |`ByteArray`
-|`binary`, `array[byte]`
-|v5.4.0*
+|`binary`, `array[byte]` label:new[New in 5.4.0]
 | Binary writes are treated specifically as Neo4j's `ByteArray` type.
 Prior to 5.4.0, Spark `tinyint` arrays are persisted as a list of numbers.
 This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
 
 |`[Array of same type]`
 |`array[element]`
-|
 |In Neo4j, arrays must be consistently typed (for example, an array must contain only `Float` values). The inner Spark type matches the type mapping above.
 
 |===

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -25,8 +25,8 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 |Example: `3.141592`
 
 |`String`
-|`decimal` label:new[New in 5.4.0]
-|Example: `"16725.77423461"`
+|`decimal`
+|label:new[New in 5.4.0] Example: `"16725.77423461"`
 This mapping only applies when _writing_ to Neo4j.
 If you need to read a spark `decimal`, parse the string representation in an appropriate way for your use case.
 
@@ -51,42 +51,42 @@ If you need to read a spark `decimal`, parse the string representation in an app
 |Example: `[local-time, 12:18:11.628]`
 
 |`ZonedDateTime`
-|`timestamp` label:new[New in 5.4.0]
-|Example: `2020-09-11 12:17:39.192+02:00`
+|`timestamp`
+|label:new[New in 5.4.0] Example: `2020-09-11 12:17:39.192+02:00`
 Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC.
 
 |`LocalDateTime`
 |`timestamp`
-|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
+|label:deprecated[Deprecated since 5.4.0] Set `data.conversion` to `legacy` to continue using it.
 
 |`LocalDateTime`
-|`timestamp_ntz` label:new[New in 5.4.0]
-|Example: `2020-09-11 12:14:49.081`
+|`timestamp_ntz`
+|label:new[New in 5.4.0] Example: `2020-09-11 12:14:49.081`
 Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. 
 
 |`Integer`
 |`timestamp_ntz`
-|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
+|label:deprecated[Deprecated since 5.4.0] Set `data.conversion` to `legacy` to continue using it.
 
 |`Duration`
 |`struct { type: string, months: long, days: long, seconds: long, nanonseconds: integer, value: string }`
 |See link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Temporal functions: duration].
 
 |`Duration`
-|`duration` or `period` objects label:new[New in 5.4.0]
-|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`.
+|`duration` or `period` objects
+|label:new[New in 5.4.0] Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`.
 
 |`Long`
 |`duration` or `period` objects
-|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
+|label:deprecated[Deprecated since 5.4.0] Set `data.conversion` to `legacy` to continue using it.
 
 |`Duration`
-|Spark SQL `INTERVAL` types label:new[New in 5.4.0]
-|Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`.
+|Spark SQL `INTERVAL` types
+|label:new[New in 5.4.0] Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`.
 
 |`Long`
 |Spark SQL `INTERVAL` types
-|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
+|label:deprecated[Deprecated since 5.4.0] Set `data.conversion` to `legacy` to continue using it.
 
 |`Node`
 |`struct { <id>: long, <labels>: array[string], (PROPERTIES) }`
@@ -101,12 +101,12 @@ Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`.
 |Example: `path[(322)<-[20280:AIRLINE]-(33510)]`.  _For ease of use it is recommended to use link:https://neo4j.com/docs/cypher-manual/current/values-and-types/lists/[path functions] to return individual properties/aspects of a path from a query._
 
 |`ByteArray`
-|`binary`, `array[byte]` label:new[New in 5.4.0]
-| Binary writes are treated specifically as Neo4j's `ByteArray` type.
+|`binary`, `array[byte]`
+|label:new[New in 5.4.0] Binary writes are treated specifically as Neo4j's `ByteArray` type.
 
 |`List<Integer>`
 |`binary`, `array[byte]`
-|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
+|label:deprecated[Deprecated since 5.4.0] Set `data.conversion` to `legacy` to continue using it.
 
 |`[Array of same type]`
 |`array[element]`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -79,7 +79,9 @@ Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. Prior t
 |`Duration`
 |`duration` or `period` objects
 |v5.4.0*
-|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`. Prior to 5.4.0, Spark durations and intervals are stored as long. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
+|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`. 
+Prior to 5.4.0, Spark durations and intervals are stored as `long`.
+This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
 
 |`Duration`
 |Spark SQL `INTERVAL` types

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -88,7 +88,9 @@ This behavior can be restored after 5.4.0 by setting `type.conversion` to `legac
 |`Duration`
 |Spark SQL `INTERVAL` types
 |v5.4.0*
-|Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`. Prior to 5.4.0, Spark durations and intervals are stored as long. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
+|Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`.
+Prior to 5.4.0, Spark durations and intervals are stored as `long`.
+This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
 
 |`Node`
 |`struct { <id>: long, <labels>: array[string], (PROPERTIES) }`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -63,7 +63,9 @@ If you need to read a spark `decimal`, please parse the string representation in
 |`timestamp`
 |v5.4.0*
 |Example: `2020-09-11 12:17:39.192+02:00`
-Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC. Prior to 5.4.0. these timestamps are written as `LocalDateTime`. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
+Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC. 
+Prior to 5.4.0. these timestamps are written as `LocalDateTime`.
+This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
 
 |`LocalDateTime`
 |`timestamp_ntz`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -4,7 +4,7 @@
 Neo4j and Cypher provide a link:https://neo4j.com/docs/java-reference/current/extending-neo4j/values-and-types/[type system]
 that describes how values are stored in the database, but these types do not always exactly match what Spark provides.
 
-In some cases, there are data types that Neo4j provides that Spark does not have an equivalent for, and vice versa.  
+In some cases, there are data types that Neo4j provides that Spark does not have an equivalent for, and vice versa.
 
 == Data type mappings
 
@@ -17,12 +17,18 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 |Example: `"Hello"`
 
 |`Integer`
-|`long`
+|`long`, `short`, `byte`
 |Example:  `12345`
 
 |`Float`
 |`double`
 |Example: `3.141592`
+
+|`String`
+|`decimal`
+|Example: `"16725.77423461"`
+This mapping only applies when _writing_ to Neo4j.
+If you need to read a spark `decimal`, please parse the string representation in an appropriate way for your use case.
 
 |`Boolean`
 |`boolean`
@@ -58,6 +64,14 @@ If you need to write a `DateTime`, use a xref:write/query.adoc[Cypher write quer
 |`struct { type: string, months: long, days: long, seconds: long, nanonseconds: integer, value: string }`
 |See link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Temporal functions: duration]
 
+|`Duration`
+|`duration` or `period` objects
+|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`
+
+|`Duration`
+|Spark SQL `INTERVAL` types
+|Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`
+
 |`Node`
 |`struct { <id>: long, <labels>: array[string], (PROPERTIES) }`
 |Nodes in Neo4j are represented as property containers; that is they appear as structs with properties corresponding to whatever properties were in the node.  _For ease of use it is usually better to return individual properties than a node from a query._
@@ -69,6 +83,10 @@ If you need to write a `DateTime`, use a xref:write/query.adoc[Cypher write quer
 |`Path`
 |`string`
 |Example: `path[(322)<-[20280:AIRLINE]-(33510)]`.  _For ease of use it is recommended to use link:https://neo4j.com/docs/cypher-manual/current/values-and-types/lists/[path functions] to return individual properties/aspects of a path from a query._
+
+|`ByteArray`
+|`binary`, `array[byte]`
+| Binary writes are treated specifically as Neo4j's `ByteArray` type.
 
 |`[Array of same type]`
 |`array[element]`
@@ -261,6 +279,7 @@ MyNodeWithFlattenedMap {
 .Spark to Cypher constraint type mapping
 |===
 |Spark type |Neo4j Type
+
 |BooleanType |BOOLEAN
 |StringType |STRING
 |IntegerType |INTEGER

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -103,8 +103,10 @@ Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`.
 |`ByteArray`
 |`binary`, `array[byte]` label:new[New in 5.4.0]
 | Binary writes are treated specifically as Neo4j's `ByteArray` type.
-Prior to 5.4.0, Spark `tinyint` arrays are persisted as a list of numbers.
-This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
+
+|`List<Integer>`
+|`binary`, `array[byte]`
+|Deprecated in 5.4.0. Set `data.conversion` to `legacy` to continue using it.
 
 |`[Array of same type]`
 |`array[element]`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -104,7 +104,9 @@ Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. Prior t
 |`ByteArray`
 |`binary`, `array[byte]`
 |v5.4.0*
-| Binary writes are treated specifically as Neo4j's `ByteArray` type. Prior to 5.4.0, Spark tinyint arrays are persisted as a list of numbers. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
+| Binary writes are treated specifically as Neo4j's `ByteArray` type.
+Prior to 5.4.0, Spark `tinyint` arrays are persisted as a list of numbers.
+This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
 
 |`[Array of same type]`
 |`array[element]`

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -28,7 +28,7 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 |Example: `3.141592`
 
 |`String`
-|`decimal`
+|`decimal` label:new[New in 5.4.0]
 |v5.4.0
 |Example: `"16725.77423461"`
 This mapping only applies when _writing_ to Neo4j.

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -10,86 +10,105 @@ In some cases, there are data types that Neo4j provides that Spark does not have
 
 .Spark to Neo4j type mapping reference
 |===
-|Neo4j type |Spark type |Notes
+|Neo4j type |Spark type |Since | Notes
 
 |`String`
 |`string`
+|
 |Example: `"Hello"`
 
 |`Integer`
 |`long`, `short`, `byte`
+|
 |Example:  `12345`
 
 |`Float`
 |`double`
+|
 |Example: `3.141592`
 
 |`String`
 |`decimal`
+|v5.4.0
 |Example: `"16725.77423461"`
 This mapping only applies when _writing_ to Neo4j.
 If you need to read a spark `decimal`, please parse the string representation in an appropriate way for your use case.
 
 |`Boolean`
 |`boolean`
+|
 |Example:  `true`
 
 |`Point`
 |`struct { type: string, srid: integer, x: double, y: double, z: double }`
+|
 |For more information on spatial types in Neo4j, see link:https://neo4j.com/docs/cypher-manual/current/values-and-types/spatial/[Spatial values]
 
 |`Date`
 |`date`
+|
 |Example: `2020-09-11`
 
 |`Time`
 |`struct { type: string, value: string }`
+|
 |Example: `[offset-time, 12:14:08.209Z]`
 
 |`LocalTime`
 |`struct { type: string, value: string }`
+|
 |Example: `[local-time, 12:18:11.628]`
 
-|`DateTime`
+|`ZonedDateTime`
 |`timestamp`
-|Example: `2020-09-11 12:17:39.192`
-This mapping only applies when _reading_ from Neo4j; otherwise, a `timestamp` is _written_ to Neo4j as a `LocalDateTime`.
-If you need to write a `DateTime`, use a xref:write/query.adoc[Cypher write query].
+|v5.4.0*
+|Example: `2020-09-11 12:17:39.192+02:00`
+Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC. Prior to 5.4.0. these timestamps are written as `LocalDateTime`. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
 
 |`LocalDateTime`
-|`timestamp`
+|`timestamp_ntz`
+|v5.4.0*
 |Example: `2020-09-11 12:14:49.081`
+Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. Prior to 5.4.0. these timestamps are written as a numerical value. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
 
 |`Duration`
 |`struct { type: string, months: long, days: long, seconds: long, nanonseconds: integer, value: string }`
-|See link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Temporal functions: duration]
+|
+|See link:https://neo4j.com/docs/cypher-manual/current/values-and-types/temporal/#cypher-temporal-durations[Temporal functions: duration].
 
 |`Duration`
 |`duration` or `period` objects
-|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`
+|v5.4.0*
+|Example: `java.time.Duration.ofDays(42)` or `java.time.Period.ofMonths(5)`. Prior to 5.4.0, Spark durations and intervals are stored as long. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
 
 |`Duration`
 |Spark SQL `INTERVAL` types
-|Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`
+|v5.4.0*
+|Example: `INTERVAL '10 05:30' DAY TO MINUTE`, `INTERVAL '4-5' YEAR TO MONTH` or `timestamp('2025-01-02 18:30:00.454') - timestamp('2024-01-01 00:00:00')`. Prior to 5.4.0, Spark durations and intervals are stored as long. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
 
 |`Node`
 |`struct { <id>: long, <labels>: array[string], (PROPERTIES) }`
+|
 |Nodes in Neo4j are represented as property containers; that is they appear as structs with properties corresponding to whatever properties were in the node.  _For ease of use it is usually better to return individual properties than a node from a query._
 
 |`Relationship`
 |`struct { <rel.id>: long, <rel.type>: string, <source.id>: long, <target.id>: long, (PROPERTIES) }`
+|
 |Relationships are returned as maps, identifying the source and target of the relationship, its type, along with properties (if any) of the relationship.  _For ease of use it is usually better to return individual properties than a relationship from a query._
 
 |`Path`
 |`string`
+|
 |Example: `path[(322)<-[20280:AIRLINE]-(33510)]`.  _For ease of use it is recommended to use link:https://neo4j.com/docs/cypher-manual/current/values-and-types/lists/[path functions] to return individual properties/aspects of a path from a query._
 
 |`ByteArray`
 |`binary`, `array[byte]`
-| Binary writes are treated specifically as Neo4j's `ByteArray` type.
+|v5.4.0*
+| Binary writes are treated specifically as Neo4j's `ByteArray` type. Prior to 5.4.0, Spark tinyint arrays are persisted as a list of numbers. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
 
 |`[Array of same type]`
 |`array[element]`
+|
 |In Neo4j, arrays must be consistently typed (for example, an array must contain only `Float` values). The inner Spark type matches the type mapping above.
 
 |===

--- a/modules/ROOT/pages/types.adoc
+++ b/modules/ROOT/pages/types.adoc
@@ -69,7 +69,9 @@ Spark timestamps (`TIMESTAMP`) are written as `ZonedDateTime` in UTC. Prior to 5
 |`timestamp_ntz`
 |v5.4.0*
 |Example: `2020-09-11 12:14:49.081`
-Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. Prior to 5.4.0. these timestamps are written as a numerical value. This behavior can be restored after 5.4.0 with the setting `type.conversion` set to `legacy`.
+Spark local timestamps (`TIMESTAMP_NTZ`) are written as `LocalDateTime`. 
+Prior to 5.4.0. these timestamps are written as a numerical value.
+This behavior can be restored after 5.4.0 by setting `type.conversion` to `legacy`.
 
 |`Duration`
 |`struct { type: string, months: long, days: long, seconds: long, nanonseconds: integer, value: string }`

--- a/modules/ROOT/pages/write/options.adoc
+++ b/modules/ROOT/pages/write/options.adoc
@@ -72,7 +72,10 @@ label:new[New in 5.3.10]
 |No
 
 |`relationship.properties`
-|Map used as keys for specifying the *relationship* properties. Used only if `relationship.save.strategy` is `keys`
+|Used only if `relationship.save.strategy` is `keys`.
+Map used as keys for specifying the *relationship* properties.
+When set, only the relationships included in the map are set as relationship properties. footnote:[Before 5.4.0, relationship properties not included in the map were set too with their original names.]
+When the option is not set, all unmapped fields are set as relationship properties.
 |_(empty)_
 |No
 

--- a/modules/ROOT/pages/write/options.adoc
+++ b/modules/ROOT/pages/write/options.adoc
@@ -31,6 +31,11 @@ The DataSource Writer has several options to connect and persist data into Neo4j
 |0
 |No
 
+|`index.await.timeout`
+|Adjust the maximum timeout to wait for index generation. Before writing, Cpyher procedure `db.awaitIndexes` will be called with specified timeout in whole seconds. Set to `0` to disable
+|300
+|No
+
 4+|*Node specific options*
 
 |`node.keys`

--- a/modules/ROOT/pages/write/options.adoc
+++ b/modules/ROOT/pages/write/options.adoc
@@ -32,7 +32,9 @@ The DataSource Writer has several options to connect and persist data into Neo4j
 |No
 
 |`index.await.timeout`
-|Adjust the maximum timeout to wait for index generation. Before writing, Cpyher procedure `db.awaitIndexes` will be called with specified timeout in whole seconds. Set to `0` to disable
+|Adjust the maximum timeout to wait for index generation.
+Before writing, the `db.awaitIndexes` Cypher procedure will be called with the timeout specified in whole seconds.
+Set to `0` to disable.
 |300
 |No
 

--- a/modules/ROOT/pages/write/options.adoc
+++ b/modules/ROOT/pages/write/options.adoc
@@ -38,6 +38,11 @@ Set to `0` to disable.
 |300
 |No
 
+|`type.conversion` label:new[v5.4]
+|Data conversion logic. When set to `legacy`, timestamps, intervals and byte arrays are processed the same way as they were before 5.4.0. See xref:../types.adoc[] for more information.
+|`default`
+|No
+
 4+|*Node specific options*
 
 |`node.keys`


### PR DESCRIPTION
not yet included in a release but brief is:

- db.indexAwait
- byte type support
- short type support
- decimal type support
- duration type support
- timestampNZ type support

related to CONN-341