### PR TITLE
docs: do not imply Spark 4 is officially supported

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ It supports both the Community and the Enterprise Edition.
 
 === Spark and Scala compatibility
 
-The connector currently supports Spark versions 3.3, 3.4 and 3.5 as well as Databricks 12.2+ with Scala 2.12 and Scala 2.13.
+The connector currently supports Spark versions 3.3, 3.4 and 3.5 as well as Databricks 12.2, 13.3, 14.3 with Scala 2.12 and Scala 2.13.
 
 == Training
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -27,7 +27,7 @@ It supports both the Community and the Enterprise Edition.
 
 === Spark and Scala compatibility
 
-The connector currently supports Spark 3.3.2+ and Databricks 12.2+ with Scala 2.12 and Scala 2.13.
+The connector currently supports Spark versions 3.3, 3.4 and 3.5 as well as Databricks 12.2+ with Scala 2.12 and Scala 2.13.
 
 == Training
 

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -12,7 +12,7 @@ Here is a compatibility table to help you choose the correct version of the conn
 |===
 | Spark Version | Artifact (*Scala 2.12*) | Artifact (*Scala 2.13*)
 
-|*3.4+*
+|*3.4*, *3.5*
 |`org.neo4j:neo4j-connector-apache-spark_2.12:{exact-connector-version}_for_spark_3`
 |`org.neo4j:neo4j-connector-apache-spark_2.13:{exact-connector-version}_for_spark_3`
 


### PR DESCRIPTION
Spark 4 support will be official when the new major release of the Spark connectors happens.