### PR TITLE
docs: update to upcoming Spark version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -9,7 +9,7 @@ asciidoc:
   attributes:
     theme: docs
     connector-version: '5.4'
-    exact-connector-version: '5.4.0'
+    exact-connector-version: '5.4.1'
     scala-version: '2.12'
     exact-scala-version: '2.12.20'
     spark-version: '3.5.6'


### PR DESCRIPTION
The 5.4.1 release only includes a bugfix around custom resolvers (URL parameter).
The aforementioned setting is already documented, so nothing to do apart from a version bump.